### PR TITLE
TextField to StringField in forms

### DIFF
--- a/project/server/user/forms.py
+++ b/project/server/user/forms.py
@@ -2,17 +2,17 @@
 
 
 from flask_wtf import Form
-from wtforms import TextField, PasswordField
+from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Email, Length, EqualTo
 
 
 class LoginForm(Form):
-    email = TextField('Email Address', [DataRequired(), Email()])
+    email = StringField('Email Address', [DataRequired(), Email()])
     password = PasswordField('Password', [DataRequired()])
 
 
 class RegisterForm(Form):
-    email = TextField(
+    email = StringField(
         'Email Address',
         validators=[DataRequired(), Email(message=None), Length(min=6, max=40)])
     password = PasswordField(


### PR DESCRIPTION
The TextField alias for StringField will be deprecated in wtforms 3.

http://wtforms.readthedocs.io/en/latest/whats_new.html