### PR TITLE
Upgrade to sqlalchemy package

### DIFF
--- a/{{cookiecutter.app_slug}}/requirements.txt
+++ b/{{cookiecutter.app_slug}}/requirements.txt
@@ -6,7 +6,7 @@ Flask-Bootstrap==3.3.7.1
 Flask-DebugToolbar==0.11.0
 Flask-Login==0.5.0
 Flask-Migrate==2.5.2
-Flask-SQLAlchemy==2.4.1
+Flask-SQLAlchemy==2.5.1
 Flask-Testing==0.7.1
 Flask-WTF==0.14.3
 psycopg2-binary==2.8.4


### PR DESCRIPTION
Version 2.5.x of sqlalchemy has a fix for the fact that the url object is immutable from version 1.4:

https://github.com/pallets/flask-sqlalchemy/issues/910#issuecomment-802098285

Without this, running `python manage.py create-db` fails with:

```
...
  File "/Users/afraz/.pyenv/versions/3.7.2/lib/python3.7/site-packages/flask_sqlalchemy/__init__.py", line 908, in apply_driver_hacks
    sa_url.database = os.path.join(app.root_path, sa_url.database)                                                                       
AttributeError: can't set attribute  
```
